### PR TITLE
Merge non-Setsid props in, use path to find 'true'

### DIFF
--- a/process.go
+++ b/process.go
@@ -37,14 +37,15 @@ func Background(cmd *exec.Cmd) (*Group, error) {
 
 	// NOTE: Cannot setsid and and setpgid in one child. Would need double fork or exec,
 	// which makes things very hard.
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true,
-		}
-
-	} else {
-		return nil, errUnimplemented
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Setsid {
+		return nil, fmt.Errorf("May not be used with a cmd.SysProcAttr.Setsid = true")
 	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+
+	cmd.SysProcAttr.Setpgid = true
 
 	// Try to start process
 	go startProcess(cmd, startc, waitc)

--- a/process_test.go
+++ b/process_test.go
@@ -34,6 +34,18 @@ func TestAlreadyExecutedFails(t *testing.T) {
 	}
 }
 
+func TestSetsidConflictFails(t *testing.T) {
+	t.Parallel()
+	what := "true"
+	cmd := exec.Command(what)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	_, err := Background(cmd)
+	wantErr := errors.New("May not be used with a cmd.SysProcAttr.Setsid = true")
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("got %v, expected error %v", err, wantErr)
+	}
+}
+
 func TestStartingNonExistingFailsRightAway(t *testing.T) {
 	t.Parallel()
 	cmd := exec.Command("/var/run/nonexistant")
@@ -46,7 +58,7 @@ func TestStartingNonExistingFailsRightAway(t *testing.T) {
 
 func TestBackgroundingWorks(t *testing.T) {
 	t.Parallel()
-	what := "/bin/true"
+	what := "true"
 	cmd := exec.Command(what)
 	g, err := Background(cmd)
 	if err != nil {


### PR DESCRIPTION
We needed to pass in an additional SysProcAttr, so I added in merging. Also clarified the error a little bit. 

true was located at /usr/bin/true instead of /bin/true, so I needed
to let the os resolve the bin using the path instead.